### PR TITLE
DEVPROD-9367 Expand Bazel variables in flags passed to bazel_clang_tidy

### DIFF
--- a/clang_tidy/clang_tidy.bzl
+++ b/clang_tidy/clang_tidy.bzl
@@ -141,6 +141,9 @@ def _safe_flags(flags):
 
     return [flag for flag in flags if flag not in unsupported_flags]
 
+def _expand_flags(ctx, flags):
+    return [ctx.expand_make_variables("clang_tidy_expand_flags", flag, ctx.var) for flag in flags]
+
 def _clang_tidy_aspect_impl(target, ctx):
     # if not a C/C++ target, we are not interested
     if not CcInfo in target:
@@ -168,8 +171,8 @@ def _clang_tidy_aspect_impl(target, ctx):
     compilation_context = target[CcInfo].compilation_context
 
     rule_flags = ctx.rule.attr.copts if hasattr(ctx.rule.attr, "copts") else []
-    c_flags = _safe_flags(_toolchain_flags(ctx, ACTION_NAMES.c_compile) + rule_flags) + ["-xc"]
-    cxx_flags = _safe_flags(_toolchain_flags(ctx, ACTION_NAMES.cpp_compile) + rule_flags) + ["-xc++"]
+    c_flags = _expand_flags(ctx, _safe_flags(_toolchain_flags(ctx, ACTION_NAMES.c_compile) + rule_flags) + ["-xc"])
+    cxx_flags = _expand_flags(ctx, _safe_flags(_toolchain_flags(ctx, ACTION_NAMES.cpp_compile) + rule_flags) + ["-xc++"])
 
     srcs = _rule_sources(ctx)
 


### PR DESCRIPTION
Currently C/C++ flags like $(GENDIR) are not expanded when passed to bazel_clang_tidy: https://parsley.mongodb.com/evergreen/mongodb_mongo_master_amazon_linux2_arm64_dynamic_compile_run_bazel_clang_tidy_patch_54b4b9ea3c33c7a345ef44aa507c87bc49589da5_66a4367e6e1bdb00076283fc_24_07_26_23_51_30/0/task?bookmarks=0%2C2485&selectedLineRange=L1551&shareLine=1551

Since we now rely on [GENDIR](https://github.com/10gen/mongo/blob/master/bazel/mongo_src_rules.bzl#L1067) expanding, this is required to make clang tidy work with generated source code or code that relies on generated source code.

Call https://bazel.build/rules/lib/builtins/ctx#expand_make_variables to expand the flags passed in