### PR TITLE
SERVER-94048 Re-order include directives in clang-tidy plugin

### DIFF
--- a/clang_tidy/clang_tidy.bzl
+++ b/clang_tidy/clang_tidy.bzl
@@ -51,16 +51,6 @@ def _run_tidy(
     # start args passed to the compiler
     args.add("--")
 
-    # add args specified by the toolchain, on the command line and rule copts
-    args.add_all(flags)
-
-    # add defines
-    for define in compilation_context.defines.to_list():
-        args.add("-D" + define)
-
-    for define in compilation_context.local_defines.to_list():
-        args.add("-D" + define)
-
     # add includes
     for i in compilation_context.framework_includes.to_list():
         args.add("-F" + i)
@@ -71,6 +61,16 @@ def _run_tidy(
     args.add_all(compilation_context.quote_includes.to_list(), before_each = "-iquote")
 
     args.add_all(compilation_context.system_includes.to_list(), before_each = "-isystem")
+
+    # add args specified by the toolchain, on the command line and rule copts
+    args.add_all(flags)
+
+    # add defines
+    for define in compilation_context.defines.to_list():
+        args.add("-D" + define)
+
+    for define in compilation_context.local_defines.to_list():
+        args.add("-D" + define)
 
     ctx.actions.run(
         inputs = inputs,


### PR DESCRIPTION
Include directives break in clang-tidy due to the toolchain directives being specified before the target directives.

All mainstream C++ compilers search the include directives left-to-right, so in effect the left-most directories take priority over the right-most ones.

What happens in pcre is the /usr/include pcre2.h path is prioritized over the pcre2.h path in the third party directory.

Re-order the include directives to specify the target paths before the toolchain paths. Note that -I and -isystem paths are explicitly ordered relative to each other, as in all -i directories are ordered separately from all -isystem directories.